### PR TITLE
Add image for Node.js 12 (active LTS)

### DIFF
--- a/12-alpine/Dockerfile
+++ b/12-alpine/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:12-alpine
+
+MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+
+RUN \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk --no-cache  update \
+  && apk --no-cache  upgrade \
+  && apk add --no-cache --virtual .build-deps \
+    gifsicle pngquant optipng libjpeg-turbo-utils \
+    udev ttf-opensans chromium \
+  && rm -rf /var/cache/apk/* /tmp/*
+
+ENV CHROME_BIN /usr/bin/chromium-browser
+ENV LIGHTHOUSE_CHROMIUM_PATH /usr/bin/chromium-browser


### PR DESCRIPTION
This adds an image based on node:12-alpine which is an active LTS version [as of October 21st 2019](https://nodejs.org/en/about/releases).

At the time of this writing, this image will include the following versions:
```bash
$ node --version
v12.13.1

$ chromium-browser --version
Chromium 78.0.3904.108
```
