### PR TITLE
Node-14-alpine-labels

### DIFF
--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/12-alpine/Dockerfile
+++ b/12-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/12-alpine/Dockerfile
+++ b/12-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/14-apline/Dockerfile
+++ b/14-apline/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine as base
+
+RUN \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk --no-cache  update \
+  && apk --no-cache  upgrade \
+  && apk add --no-cache --virtual .build-deps \
+    gifsicle pngquant optipng libjpeg-turbo-utils \
+    udev ttf-opensans chromium \
+  && rm -rf /var/cache/apk/* /tmp/*
+
+ENV CHROME_BIN /usr/bin/chromium-browser
+ENV LIGHTHOUSE_CHROMIUM_PATH /usr/bin/chromium-browser

--- a/14-apline/Dockerfile
+++ b/14-apline/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine as base
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/14-apline/Dockerfile
+++ b/14-apline/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14-alpine as base
 
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
+
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
   && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \

--- a/4-alpine/Dockerfile
+++ b/4-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:4-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/4-alpine/Dockerfile
+++ b/4-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:4-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/7-alpine/Dockerfile
+++ b/7-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:7-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/7-alpine/Dockerfile
+++ b/7-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:7-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8-alpine
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL Aleksandar Diklic "https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8-alpine
 
-LABEL Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM node:%VERSION%
 
-MAINTAINER Aleksandar Diklic "https://github.com/rastasheep"
+LABEL org.opencontainers.image.authors="Aleksandar Diklic https://github.com/rastasheep"
 
 RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # alpine-node-chromium
+
 ### Dockerized chromium, built on top of [official Node alpine](https://hub.docker.com/_/node/) images.
 
 ## About image
@@ -13,6 +14,7 @@
 Image intended to be used in modern front-end development workflow, to be exact, with [Karma test runner](https://karma-runner.github.io/1.0/index.html) via [karma-chrome-launcher](https://github.com/karma-runner/karma-chrome-launcher) which uses headless Chromium instead traditional PhantomJS which doesn't play well with Alpine linux.
 
 If you're interested into actual Karma configuration, it looks like:
+
 ```
   browsers: ['ChromiumNoSandbox'],
   customLaunchers: {
@@ -25,6 +27,9 @@ If you're interested into actual Karma configuration, it looks like:
 
 ### • Image tags
 
+- rastasheep/alpine-node-chromium:14-alpine (based on: node:14-alpine)
+- rastasheep/alpine-node-chromium:12-alpine (based on: node:12-alpine)
+- rastasheep/alpine-node-chromium:10-alpine (based on: node:10-alpine)
 - rastasheep/alpine-node-chromium:8-alpine (based on: node:8-alpine)
 - rastasheep/alpine-node-chromium:7-alpine (based on: node:7-alpine)
 - rastasheep/alpine-node-chromium:6-alpine (based on: node:6-alpine)
@@ -33,17 +38,20 @@ If you're interested into actual Karma configuration, it looks like:
 ### • Installed packages
 
 Chromium stuff
+
 - [udev](https://pkgs.alpinelinux.org/package/v3.5/main/x86_64/udev)
 - [ttf-opensans](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ttf-opensans)
 - [chromium](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium)
 
 Image optimization libs
+
 - [gifsicle](https://pkgs.alpinelinux.org/package/edge/community/x86_64/gifsicle)
 - [pngquant](https://pkgs.alpinelinux.org/package/edge/community/x86_64/pngquant)
 - [optipng](https://pkgs.alpinelinux.org/package/v3.6/community/x86_64/optipng)
 - [libjpeg-turbo-utils](https://pkgs.alpinelinux.org/package/edge/main/x86_64/libjpeg-turbo-utils)
 
 ### • Environment variables
+
 - `CHROME_BIN=/usr/bin/chromium-browser`
 - `LIGHTHOUSE_CHROMIUM_PATH=/usr/bin/chromium-browser`
 
@@ -54,4 +62,3 @@ If you run into any problems with this image, please check (and potentially file
 ## License
 
 alpine-node-chromium is licensed under the [MIT license](http://opensource.org/licenses/MIT).
-


### PR DESCRIPTION
Good day Aleksandar, 

Added the version for Node 14 using the same configuration as usual since I noticed that Angular 12 does not work with the image using node 12. I'm already using this configuration in a project so I can confirm there is no issues with the original configuration you created. 

I also replaced the MAINTAINER with LABEL following the documentation https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Thanks for the images, helps a lot for CI/CD.